### PR TITLE
Support Shapely 2

### DIFF
--- a/shape.py
+++ b/shape.py
@@ -423,6 +423,14 @@ class Shape(Polygon):
 
         super(Shape, self).__init__(shell, holes=holes)
 
+    def __setattr__(self, name, value):
+        ''' Bypass Shapely 1.8+ __setattr__ method '''
+        try:
+            super().__getattribute__(name)
+            super().__setattr__(name, value)
+        except AttributeError:
+            object.__setattr__(self, name, value)
+
     def copy(self):
         '''
         Create a copy of the current Shape.
@@ -951,13 +959,14 @@ class Shape(Polygon):
                                "without advanced triangulation methods. "
                                "Please install PyOpenGL for faster seeding "
                                "inside complex shapes.")
+
                 points = []
-                p = Point()
+
                 while len(points) < neurons:
                     new_x = uniform(min_x, max_x, neurons-len(points))
                     new_y = uniform(min_y, max_y, neurons-len(points))
                     for x, y in zip(new_x, new_y):
-                        p.coords = (x, y)
+                        p = Point(x, y)
                         if seed_area.contains(p):
                             points.append((x, y))
                 positions = np.array(points)

--- a/shape_io.py
+++ b/shape_io.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from shapely.affinity import affine_transform
 from shapely.geometry import MultiPolygon
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 from .shape import Shape
 from .tools import pop_largest
@@ -263,7 +263,7 @@ def culture_from_file(filename, min_x=None, max_x=None, unit='um',
         assert valid, "Some polygons are not contained in the main container."
 
     internal_shapes = \
-        cascaded_union(internal_shapes) if internal_shapes else Shape([])
+        unary_union(internal_shapes) if internal_shapes else Shape([])
 
     if internal_shapes_as == "holes":
         diff           = main_container.difference(internal_shapes)


### PR DESCRIPTION
This migrates Shapely tools and functions to be prepared for the [move to 2.0](https://shapely.readthedocs.io/en/stable/migration.html).