### PR TITLE
Workaround loss of _other_owned and readonly _geom

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -73,7 +73,7 @@ except ImportError:
 from .tools import pop_largest
 
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"
 
 
 # -------------------- #

--- a/examples/gen_obstacles.py
+++ b/examples/gen_obstacles.py
@@ -29,13 +29,11 @@ import PyNCulture as nc
 
 shape = nc.Shape.disk(radius=2500.)
 
-params           = {"height": 250., "width":250.}
-#~ filling_fraction = 0.4*shape.area/(5000.**2)
-#~ filling_fraction = 0.4*(5000.**2)/shape.area
+params = {"height": 250., "width":250.}
 filling_fraction = 0.4
 
-shape.random_obstacles(filling_fraction, form="rectangle", params=params,
-                       heights=30., etching=20.)
+shape = shape.random_obstacles(filling_fraction, form="rectangle",
+                               params=params, heights=30., etching=20.)
 
 
 ''' Seed neurons '''


### PR DESCRIPTION
Shapely removed the ``_other_owned`` attribute and made ``_geom`` readonly so some previous tricks are no longer working.